### PR TITLE
feat: launch modules from docker images

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,11 @@ address = "127.0.0.1:33950"
 key_path = "keys.example.json"
 
 [[modules]]
-id = "DA_COMMIT"
+id = "DA_COMMIT_RAW"
 path = "target/debug/da_commit"
+sleep_secs = 5
+
+[[modules]]
+id = "DA_COMMIT"
+docker_image="da_commit"
 sleep_secs = 5

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,11 +17,6 @@ address = "127.0.0.1:33950"
 key_path = "keys.example.json"
 
 [[modules]]
-id = "DA_COMMIT_RAW"
-path = "target/debug/da_commit"
-sleep_secs = 5
-
-[[modules]]
 id = "DA_COMMIT"
 docker_image="da_commit"
 sleep_secs = 5

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,3 +23,5 @@ eyre.workspace = true
 
 tree_hash.workspace = true
 tree_hash_derive.workspace = true
+
+bollard = "0.16.1"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,7 +1,7 @@
 use std::process::Stdio;
 
 use cb_common::{
-    config::{CommitBoostConfig, CONFIG_PATH_ENV, MODULE_ID_ENV},
+    config::{CommitBoostConfig, ModuleSource, CONFIG_PATH_ENV, MODULE_ID_ENV},
     utils::print_logo,
 };
 use cb_crypto::service::SigningService;
@@ -69,24 +69,53 @@ impl Args {
             Command::Start { config: config_path } => {
                 let config = CommitBoostConfig::from_file(&config_path);
 
+                // Initialize Docker client
+                let docker = bollard::Docker::connect_with_local_defaults().expect("Failed to connect to Docker");
+
                 if let Some(modules) = config.modules {
                     let signer_config = config.signer.expect("missing signer config with modules");
+                    // start signing server
+                    tokio::spawn(SigningService::run(config.chain, signer_config));
 
                     // this mocks the commit boost client starting containers, processes etc
                     let mut child_handles = Vec::with_capacity(modules.len());
 
                     for module in modules {
-                        let child = std::process::Command::new(module.path)
-                            .env(MODULE_ID_ENV, module.id)
-                            .env(CONFIG_PATH_ENV, &config_path)
-                            .spawn()
-                            .expect("failed to start process");
+                        match module.source {
+                            ModuleSource::DockerImageId(docker_image) => {
+                                let config = bollard::container::Config {
+                                    image: Some(docker_image.clone()),
+                                    host_config: Some(bollard::secret::HostConfig {
+                                        binds: {
+                                            let full_config_path = std::fs::canonicalize(&config_path).unwrap().to_string_lossy().to_string();
+                                            Some(vec![format!("{}:{}", full_config_path, "/config.toml")])
+                                        },
+                                        network_mode: Some(String::from("host")), // Use the host network
+                                        ..Default::default()
+                                    }),
+                                    env: Some(vec![
+                                        format!("{}={}", MODULE_ID_ENV, module.id),
+                                        format!("{}={}", CONFIG_PATH_ENV, "/config.toml"),
+                                    ]),
+                                    ..Default::default()
+                                };
 
-                        child_handles.push(child);
+                                let container = docker.create_container::<&str, String>(None, config).await?;
+                                let container_id = container.id;
+                                docker.start_container::<String>(&container_id, None).await?;
+                                println!("Started container: {} from image {}", container_id, &docker_image);
+                            },
+                            ModuleSource::Path(path) => {
+                                let child = std::process::Command::new(path)
+                                    .env(MODULE_ID_ENV, module.id)
+                                    .env(CONFIG_PATH_ENV, &config_path)
+                                    .spawn()
+                                    .expect("failed to start process");
+
+                                child_handles.push(child);
+                            },
+                        }
                     }
-
-                    // start signing server
-                    tokio::spawn(SigningService::run(config.chain, signer_config));
                 }
 
                 // start pbs server

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -113,55 +113,11 @@ const fn default_u256() -> U256 {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub enum ModuleSource {
-    #[serde(rename = "path")]
-    Path(String),
-    #[serde(rename = "docker_image")]
-    DockerImageId(String),
-}
-
-#[derive(Debug, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct ModuleConfig<T = ()> {
     pub id: String,
-    #[serde(flatten)]
-    pub source: ModuleSource,
+    pub docker_image: String,
     #[serde(flatten)]
     pub extra: T,
-}
-
-impl<'de, T> Deserialize<'de> for ModuleConfig<T>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct InnerModuleConfig<T> {
-            id: String,
-            path: Option<String>,
-            docker_image: Option<String>,
-            #[serde(flatten)]
-            extra: T,
-        }
-
-        let inner = InnerModuleConfig::deserialize(deserializer)?;
-
-        let source = match (inner.path, inner.docker_image) {
-            (Some(path), None) => ModuleSource::Path(path),
-            (None, Some(docker_image)) => ModuleSource::DockerImageId(docker_image),
-            (Some(_), Some(_)) => return Err(de::Error::custom("Cannot have both `path` and `docker_image`")),
-            (None, None) => return Err(de::Error::custom("Must have either `path` or `docker_image`")),
-        };
-
-        Ok(ModuleConfig {
-            id: inner.id,
-            source,
-            extra: inner.extra,
-        })
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -113,11 +113,55 @@ const fn default_u256() -> U256 {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub enum ModuleSource {
+    #[serde(rename = "path")]
+    Path(String),
+    #[serde(rename = "docker_image")]
+    DockerImageId(String),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModuleConfig<T = ()> {
     pub id: String,
-    pub path: String,
+    #[serde(flatten)]
+    pub source: ModuleSource,
     #[serde(flatten)]
     pub extra: T,
+}
+
+impl<'de, T> Deserialize<'de> for ModuleConfig<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct InnerModuleConfig<T> {
+            id: String,
+            path: Option<String>,
+            docker_image: Option<String>,
+            #[serde(flatten)]
+            extra: T,
+        }
+
+        let inner = InnerModuleConfig::deserialize(deserializer)?;
+
+        let source = match (inner.path, inner.docker_image) {
+            (Some(path), None) => ModuleSource::Path(path),
+            (None, Some(docker_image)) => ModuleSource::DockerImageId(docker_image),
+            (Some(_), Some(_)) => return Err(de::Error::custom("Cannot have both `path` and `docker_image`")),
+            (None, None) => return Err(de::Error::custom("Must have either `path` or `docker_image`")),
+        };
+
+        Ok(ModuleConfig {
+            id: inner.id,
+            source,
+            extra: inner.extra,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/pbs/src/boost.rs
+++ b/crates/pbs/src/boost.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 pub trait BuilderApi<S: BuilderApiState>: 'static {
     /// Use to extend the BuilderApi
-    fn routes() -> Option<Router<BuilderState<S>>> {
+    fn extra_routes() -> Option<Router<BuilderState<S>>> {
         None
     }
 

--- a/crates/pbs/src/routes/router.rs
+++ b/crates/pbs/src/routes/router.rs
@@ -25,7 +25,7 @@ pub fn create_app_router<S: BuilderApiState, T: BuilderApi<S>>(state: BuilderSta
 
     let builder_api = Router::new().nest(BULDER_API_PATH, builder_routes);
 
-    let app = if let Some(extra_routes) = T::routes() {
+    let app = if let Some(extra_routes) = T::extra_routes() {
         builder_api.merge(extra_routes)
     } else {
         builder_api

--- a/examples/custom_boost.rs
+++ b/examples/custom_boost.rs
@@ -42,7 +42,7 @@ impl BuilderApi<StatusCounter> for MyBuilderApi {
         Ok(())
     }
 
-    fn routes() -> Option<Router<BuilderState<StatusCounter>>> {
+    fn extra_routes() -> Option<Router<BuilderState<StatusCounter>>> {
         let router = Router::new().route("/custom/stats", get(handle_stats));
         Some(router)
     }


### PR DESCRIPTION
Adds the ability to also launch a module by creating and starting a container by a docker image provided for that module.

The `config.example.toml` is modified to launch an example replica of `da_commit` which has been dockerized. From the viewpoint of CB, it simply expects a docker image `da_commit` in the local registry. However, the dockerized version of the example module `da_commit` is not defined in this repo, but is available [here](https://github.com/LimeChain/da-commit-dockerized).

Before you launch CB, build the `da_commit` image locally. Keep in mind that you'll have to modify `Cargo.toml` to point to the accurate current version of CB before you build the image. 